### PR TITLE
provide read-po-str to parse from a string

### DIFF
--- a/src/pottery/po.clj
+++ b/src/pottery/po.clj
@@ -95,9 +95,12 @@
      [(::msgstr block) (::msgstr-plural block)]]
     [(::msgid block) (::msgstr block)]))
 
-(defn read-po-file [file]
-  (->> (str/split (slurp file) #"\n\n")
+(defn read-po-str [s]
+  (->> (str/split s #"\n\n")
        (drop 1) ;; Header meta data
        (map parse-block)
        (map ->kv)
        (into {})))
+
+(defn read-po-file [file]
+  (read-po-str (slurp file)))


### PR DESCRIPTION
Hi,

I'm proposing the following patch to allow parsing the po file from a given string.  I need this because I'm using [shadow-cljs slurp-resource](https://github.com/thheller/shadow-cljs/blob/master/src/main/shadow/resource.clj#L11) to inline parsed po files in a clojurescript application.

`slurp-resources` returns the content of the resources (equivalent to `(-> "res-path" io/resource slurp)`), in a way that shadow-cljs can recompile the bundle if that resource changes.  To inline the parsed po file as clojure map in the clojurescript files I'm doing something like this:

```clojure
;; clojure
(ns <app>.tr
  (:require [shadow.resource :as res]
            [pottery.po :as po]))

(defmacro inline-po [fname]
  (po/read-po-str (res/slurp-resource &env fname)))


;; clojurescript
(ns <app>.frontend.tr
  (:require-macros [<app>.tr :refer [inline-po]]))

(def DICT
  {:en (inline-po "gettext/en.po")
   :it (inline-po "gettext/it.po")})
```

I'm testing this (with a small pot) and it seems to work.

Cheers!

P.S.: the alternative would be to make `->kv` public, but I like this approach better.