### PR TITLE
handle multiline messages ids

### DIFF
--- a/src/pottery/po.clj
+++ b/src/pottery/po.clj
@@ -1,5 +1,6 @@
 (ns pottery.po
-  (:require [clojure.string :as str]
+  (:require [clojure.pprint :refer [cl-format]]
+            [clojure.string :as str]
             [pottery.scan :as scan]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -29,6 +30,12 @@
   (zipmap (map ::scan/value (mapcat ::scan/expressions scan-results))
           (range)))
 
+(defn- fmt-msg-id [s]
+  (let [lines (str/split s #"\n")]
+    (if (< 1 (count lines))
+      (cl-format nil "\"\"\n\"~{~a~^\\n\"\n\"~}\"" lines)
+      (cl-format nil "\"~a\"" s))))
+
 (defn gen-template
   "Takes in a list of scan results (filename + msg-ids), groups
   multiple appearances of the same msgid together and returns a ready
@@ -41,9 +48,9 @@
      (str
       (format-notes notes)
       (if (vector? msg-id)
-        (format "#: %s\nmsgid \"%s\"\nmsgid_plural \"%s\"\nmsgstr[0] \"\"\nmsgstr[1] \"\"\n"
-                (str/join " " filenames) (first msg-id) (second msg-id))
-        (format "#: %s\nmsgid \"%s\"\nmsgstr \"\"\n" (str/join " " filenames) msg-id))))))
+        (format "#: %s\nmsgid %s\nmsgid_plural %s\nmsgstr[0] \"\"\nmsgstr[1] \"\"\n"
+                (str/join " " filenames) (fmt-msg-id (first msg-id)) (fmt-msg-id (second msg-id)))
+        (format "#: %s\nmsgid %s\nmsgstr \"\"\n" (str/join " " filenames) (fmt-msg-id msg-id)))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Reading PO files

--- a/test/pottery/scan_test.clj
+++ b/test/pottery/scan_test.clj
@@ -7,6 +7,8 @@
     (are [expr result] (= result (::sut/value (sut/extract sut/default-extractor expr)))
       '(tr "Hello") "Hello"
       '(tr "Hello %s" arg1) "Hello %s"
+      '(tr "Hello\nthere") "Hello\nthere"
+      '(tr "Hello:\n%s" arg1) "Hello:\n%s"
       '(trn ["One" "Many"] 1) ["One" "Many"]
       '(trn ["One %s" "Many %s" arg1] 3) ["One %s" "Many %s"])
 
@@ -26,7 +28,9 @@
       (are [expr result] (= result (::sut/value (extract expr)))
         '(tr ["Hello"])               "Hello"
         '(tr ["Hello %1!" arg1 arg2]) "Hello %1!"
+        '(tr ["Hello\n%1" arg1 arg2]) "Hello\n%1"
         '(trn ["Item" "Items"] 2)     ["Item" "Items"]
+        '(trn ["It\nem" "It\nems"] 2) ["It\nem" "It\nems"]
         '(inc 6)                      nil
         "foo"                         nil)
 


### PR DESCRIPTION
Hi,

I found that multiline message ids aren't handled correctly.  Let's say we have a translation string like this:

```clj
(tr "Info:\nUsername: %s\nBrowser: %s\nLocation: %s" ,,,)
```

then the PO file will be something like:

```
#: src/foo/example.clj
msgid "Info:
Username: %s
Browser: %s
Location: %s"
msgstr ""
```

and that's not the correct syntax AFAIK.  In fact, poedit truncates the msg id to "Info".  The correct output should be

```
#: src/foo/example.clj
msgid ""
"Info:\n"
"Username: %s\n"
"Browser: %s\n"
"Location: %s"
msgstr ""
```

So, this PR is my take on this problem: with this I am able to export multiline translation strings as POT file, translate 'em with poedit and parse the resulting PO file back with pottery.

I'll be the first to say that `fmt-msg-id` is a *terrible* name for a function, but I'm not too inspired tonight, apologies.  Also, the choice to use `cl-format` may be too brave but, while the format string seems some sort of line noise, I fear that any more verbose alternative would require the same mental effort. Anyway, I don't have strong feelings towards `cl-format`, so I can change that eventually.