### PR TITLE
Avoid slurping directories

### DIFF
--- a/src/pottery/scan.clj
+++ b/src/pottery/scan.clj
@@ -10,8 +10,9 @@
 ;; Files
 
 (defn- source-file? [file]
-  (some #(re-find (re-pattern (str "." % "$")) (.getName file))
-        ["clj" "cljc" "cljs"]))
+  (and (.isFile file)
+       (some #(re-find (re-pattern (str "." % "$")) (.getName file))
+             ["clj" "cljc" "cljs"])))
 
 (defn- get-files [dir]
   (filter source-file? (file-seq (io/file dir))))


### PR DESCRIPTION
This fixes #9 by adding an additional check to the `pottery.scan/source-file?` predicate fn to verify the file given is actually a file, and not a directory.

It also adds a directory named `folder.clj` to the `test-resources` folder, so that the `potter.scan-test/scan-files-test` test fails if the fix is not applied.